### PR TITLE
fix(docker): missing build context

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,6 +17,8 @@ services:
    www:
      depends_on:
        - db
+     build:
+       context: ./
      image: intertext:latest
      volumes:
        - ./config.php:/var/www/html/config/config.php


### PR DESCRIPTION
`docker-compose` build is failing for me. Then, I found out that the build context pointing to `Dockerfile` is missing from `docker-compose.yml`. 